### PR TITLE
fix `extract_timestamp` to work with standard lib of Ruby 2.3.4

### DIFF
--- a/lib/bittrex/helpers.rb
+++ b/lib/bittrex/helpers.rb
@@ -1,10 +1,10 @@
-require 'time'
+require 'date'
 
 module Bittrex
   module Helpers
     def extract_timestamp(value)
       return if value.nil? or value.strip.empty?
-      Time.parse value
+      DateTime.parse value
     end
   end
 end

--- a/spec/models/helper_spec.rb
+++ b/spec/models/helper_spec.rb
@@ -1,36 +1,36 @@
 require 'spec_helper'
 
 describe Bittrex::Helpers do
-	include Bittrex::Helpers
-	describe '#extract_timestamp' do
-		context 'when the argument is empty' do
-			it 'returns nil' do
-				expect(extract_timestamp(nil)).to be(nil)
+  include Bittrex::Helpers
+    describe '#extract_timestamp' do
+      context 'when the argument is empty' do
+        it 'returns nil' do
+          expect(extract_timestamp(nil)).to be(nil)
+      	end
 			end
-		end
 
-		context 'when the argument is an empty string' do
-			it 'returns nil' do
-				expect(extract_timestamp('')).to be(nil)
-			end
-		end
+      context 'when the argument is an empty string' do
+        it 'returns nil' do
+          expect(extract_timestamp('')).to be(nil)
+        end
+      end
 
-		context 'when the argument is a string of spaces' do
-			it 'returns nil' do
-				expect(extract_timestamp('   ')).to be(nil)
-			end
-		end
+      context 'when the argument is a string of spaces' do
+        it 'returns nil' do
+          expect(extract_timestamp('   ')).to be(nil)
+        end
+      end
 
-		context 'when the argument is datetime string' do
-			it 'returns a datetime object' do
-				expected_time_object = DateTime.now
-				time_string = expected_time_object.to_s
-				strftime_format = '%B %d, %Y %H %M %S'
-				expect(extract_timestamp(time_string).class).to eql(DateTime)
-				expect(
-					extract_timestamp(time_string).strftime(strftime_format)
-				).to eql(expected_time_object.strftime(strftime_format))
-			end
-		end
-	end
+      context 'when the argument is datetime string' do
+        it 'returns a datetime object' do
+          expected_time_object = DateTime.now
+          time_string = expected_time_object.to_s
+          strftime_format = '%B %d, %Y %H %M %S'
+          expect(extract_timestamp(time_string).class).to eql(DateTime)
+          expect(
+                  extract_timestamp(time_string).strftime(strftime_format)
+          ).to eql(expected_time_object.strftime(strftime_format))
+        end
+      end
+    end
 end

--- a/spec/models/helper_spec.rb
+++ b/spec/models/helper_spec.rb
@@ -2,35 +2,35 @@ require 'spec_helper'
 
 describe Bittrex::Helpers do
   include Bittrex::Helpers
-    describe '#extract_timestamp' do
-      context 'when the argument is empty' do
-        it 'returns nil' do
-          expect(extract_timestamp(nil)).to be(nil)
-      	end
-			end
+  describe '#extract_timestamp' do
+    context 'when the argument is empty' do
+      it 'returns nil' do
+        expect(extract_timestamp(nil)).to be(nil)
+    	end
+		end
 
-      context 'when the argument is an empty string' do
-        it 'returns nil' do
-          expect(extract_timestamp('')).to be(nil)
-        end
-      end
-
-      context 'when the argument is a string of spaces' do
-        it 'returns nil' do
-          expect(extract_timestamp('   ')).to be(nil)
-        end
-      end
-
-      context 'when the argument is datetime string' do
-        it 'returns a datetime object' do
-          expected_time_object = DateTime.now
-          time_string = expected_time_object.to_s
-          strftime_format = '%B %d, %Y %H %M %S'
-          expect(extract_timestamp(time_string).class).to eql(DateTime)
-          expect(
-                  extract_timestamp(time_string).strftime(strftime_format)
-          ).to eql(expected_time_object.strftime(strftime_format))
-        end
+    context 'when the argument is an empty string' do
+      it 'returns nil' do
+        expect(extract_timestamp('')).to be(nil)
       end
     end
+
+    context 'when the argument is a string of spaces' do
+      it 'returns nil' do
+        expect(extract_timestamp('   ')).to be(nil)
+      end
+    end
+
+    context 'when the argument is datetime string' do
+      it 'returns a datetime object' do
+        expected_time_object = DateTime.now
+        time_string = expected_time_object.to_s
+        strftime_format = '%B %d, %Y %H %M %S'
+        expect(extract_timestamp(time_string).class).to eql(DateTime)
+        expect(
+                extract_timestamp(time_string).strftime(strftime_format)
+        ).to eql(expected_time_object.strftime(strftime_format))
+      end
+    end
+  end
 end

--- a/spec/models/helper_spec.rb
+++ b/spec/models/helper_spec.rb
@@ -1,0 +1,36 @@
+require 'spec_helper'
+
+describe Bittrex::Helpers do
+	include Bittrex::Helpers
+	describe '#extract_timestamp' do
+		context 'when the argument is empty' do
+			it 'returns nil' do
+				expect(extract_timestamp(nil)).to be(nil)
+			end
+		end
+
+		context 'when the argument is an empty string' do
+			it 'returns nil' do
+				expect(extract_timestamp('')).to be(nil)
+			end
+		end
+
+		context 'when the argument is a string of spaces' do
+			it 'returns nil' do
+				expect(extract_timestamp('   ')).to be(nil)
+			end
+		end
+
+		context 'when the argument is datetime string' do
+			it 'returns a datetime object' do
+				expected_time_object = DateTime.now
+				time_string = expected_time_object.to_s
+				strftime_format = '%B %d, %Y %H %M %S'
+				expect(extract_timestamp(time_string).class).to eql(DateTime)
+				expect(
+					extract_timestamp(time_string).strftime(strftime_format)
+				).to eql(expected_time_object.strftime(strftime_format))
+			end
+		end
+	end
+end


### PR DESCRIPTION
`parse` does not appear to be defined on [the Time object in Ruby 2.3.4](http://ruby-doc.org/core-2.3.4/Time.html). This change will allow the helper method to work with the version specified in the gem.